### PR TITLE
add responsive price counting

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -25,6 +25,7 @@ require("channels")
 // External imports
 import "bootstrap";
 import { initMapbox } from '../plugins/init_mapbox';
+import { computeTotalPrice } from '../plugins/booking';
 
 // Internal imports, e.g:
 // import { initSelect2 } from '../components/init_select2';
@@ -32,4 +33,7 @@ import { initMapbox } from '../plugins/init_mapbox';
 document.addEventListener('turbolinks:load', () => {
   // Call your functions here, e.g:
   initMapbox();
+  computeTotalPrice();
 });
+
+document.computeTotalPrice = computeTotalPrice;

--- a/app/javascript/plugins/booking.js
+++ b/app/javascript/plugins/booking.js
@@ -1,0 +1,17 @@
+const computeTotalPrice = () => {
+  let startYear = document.getElementById("booking_start_date_1i").value;
+  let startMonth = document.getElementById("booking_start_date_2i").value;
+  let startDay = document.getElementById("booking_start_date_3i").value;
+  let startDate = new Date(startYear, startMonth - 1, startDay);
+
+  let endYear = document.getElementById("booking_end_date_1i").value;
+  let endMonth = document.getElementById("booking_end_date_2i").value;
+  let endDay = document.getElementById("booking_end_date_3i").value;
+  let endDate = new Date(endYear, endMonth - 1, endDay);
+
+  let numberOfDays = (Math.floor((endDate - startDate)/1000/60/60/24)+1);
+  let pricePerDay = document.getElementById("price-per-day").innerHTML;
+  let totalPrice = document.getElementById("total-price").innerHTML = numberOfDays * pricePerDay
+};
+
+export { computeTotalPrice };

--- a/app/views/puzzles/show.html.erb
+++ b/app/views/puzzles/show.html.erb
@@ -11,10 +11,6 @@
 
     <%= render 'shared/booking-form' %>
 
-    <div>
-      <p>Total price:</p>
-    </div>
-
 
     <div class="m-2">
       <div>

--- a/app/views/shared/_booking-form.html.erb
+++ b/app/views/shared/_booking-form.html.erb
@@ -1,9 +1,10 @@
 <div class="col-4">
   <div class="card mt-3 card-right">
-    <p>Price per day: <%= @puzzle.price %></p>
+    <p>Price per day: <span id="price-per-day"><%= @puzzle.price %></span> CHF</p>
+    <p>Total price: <span id="total-price"></span> CHF</p>
     <%= simple_form_for [@puzzle, @booking] do |f| %>
-      <div class="form-inputs">
-        <%= f.input :start_date  %>
+      <div class="form-inputs" oninput="computeTotalPrice()">
+        <%= f.input :start_date %>
         <%= f.input :end_date %>
       </div>
 


### PR DESCRIPTION
I set a daily price as a default total price and counted also the last day of renting while counting the total price.
So if someone rented puzzle from 22 - 24.04 he'll be charged for 3 days. If you wouldn't like to count this last day let me know I'll change it.

https://user-images.githubusercontent.com/78602093/115765080-9a168d80-a3a6-11eb-948e-6dfad847c402.mov

